### PR TITLE
Update to Neon Target Platform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+bin

--- a/ca.ubc.cs.ferret-feature.base/build.properties
+++ b/ca.ubc.cs.ferret-feature.base/build.properties
@@ -1,8 +1,6 @@
 bin.includes = feature.xml,\
-               info/,\
                .project,\
                build.properties
-src.includes = info/,\
-               build.properties,\
+src.includes = build.properties,\
                feature.xml,\
                .project

--- a/ca.ubc.cs.ferret.pde/build.properties
+++ b/ca.ubc.cs.ferret.pde/build.properties
@@ -3,7 +3,6 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                helpContexts.xml,\
-               html/,\
                icons/
 src.includes = helpContexts.xml,\
                icons/

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeModelHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeModelHelper.java
@@ -48,6 +48,7 @@ import org.eclipse.pde.core.plugin.IPluginImport;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.IPluginObject;
 import org.eclipse.pde.core.plugin.ISharedPluginModel;
+import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.eclipse.pde.internal.core.FeatureModelManager;
 import org.eclipse.pde.internal.core.IPluginModelListener;
 import org.eclipse.pde.internal.core.PDECore;
@@ -130,7 +131,7 @@ public class PdeModelHelper implements IPluginModelListener, IRegistryChangeList
 	 */
 	protected URL[] getWorkspacePluginPaths(PDEState state) {
 		ArrayList<URL> list = new ArrayList<URL>();
-		for(IPluginModelBase pmb : state.getWorkspaceModels()) {
+		for(IPluginModelBase pmb : PluginRegistry.getWorkspaceModels()) {
 			try {
 				list.add(new File(pmb.getInstallLocation()).toURL());
 			} catch (MalformedURLException e) {}

--- a/ferret.target
+++ b/ferret.target
@@ -8,10 +8,10 @@
 <repository location="http://manumitting.com/resources/p2"/>
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.source.feature.group" version="3.7.1.r37x_v20110810-0800-7b7qFVtFEx2XnmZ4jlM5mjM"/>
-<unit id="org.eclipse.platform.sdk" version="3.7.1.M20110909-1335"/>
-<unit id="org.eclipse.pde.api.tools.ee.fragments.feature.group" version="1.0.200.r37x_v20110803-7D-FHkFAFkNZZO9PfBZStN"/>
-<repository location="http://download.eclipse.org/releases/indigo"/>
+<unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.platform.sdk" version="0.0.0"/>
+<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/releases/neon"/>
 </location>
 </locations>
 </target>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   <packaging>pom</packaging>
 
   <properties>
-    <tycho.version>0.13.0</tycho.version>
+    <tycho.version>0.26.0</tycho.version>
     <tycho.showEclipseLog>true</tycho.showEclipseLog>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.encoding>UTF-8</maven.compiler.encoding> <!-- tycho not yet using p.b.sE -->
     <findbugs.version>2.3.2-SNAPSHOT</findbugs.version>
-    <eclipse.repo>http://download.eclipse.org/releases/indigo</eclipse.repo>
+    <eclipse.repo>http://download.eclipse.org/releases/neon</eclipse.repo>
   </properties>
 
   <modules>


### PR DESCRIPTION
- Remove non-existent files (detected by Tycho 0.26.0)
- Use Neon release for Tycho builds and PDE Target Platform
- PDEState.getWorkspaceModels() -> PluginRegistry.getWorkspaceModels()

I still think there might be some issues since some tests seem to be failing, but I have no idea if that was the case even beforehand (haven't run it against Indigo + Tycho 0.13.0). I did run this in Neon and it seems to work pretty well.