### PR TITLE
Make Guava 21 available from Ferret site

### DIFF
--- a/site/metadata.product
+++ b/site/metadata.product
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+<!--
+  This product exists to bring in any required 3rd part,
+  but remains invisible.
+-->
+<product uid="ca.ubc.cs.ferret.dist" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="false">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="com.google.guava"/>
+   </plugins>
+
+   <configurations>
+   </configurations>
+
+</product>


### PR DESCRIPTION
Add new .product file for conveyancing 3rd party dependencies such as _com.google.guava_ 21.0.