### PR TITLE
Fixup PDE package-based queries

### DIFF
--- a/ca.ubc.cs.ferret.pde/plugin.xml
+++ b/ca.ubc.cs.ferret.pde/plugin.xml
@@ -85,7 +85,7 @@
         class="ca.ubc.cs.ferret.pde.queries.BundlesExportingPackage"
         id="ca.ubc.cs.ferret.pde.bundlesexportingpackage">
 		 <parameter
-		   class="org.eclipse.pde.internal.core.text.bundle.PackageObject"
+		   class="ca.ubc.cs.ferret.pde.JavaPackage"
 		   count="+"
 		   fidelity="equivalent">
 		 </parameter>
@@ -95,7 +95,7 @@
         class="ca.ubc.cs.ferret.pde.queries.BundlesImportingPackage"
         id="ca.ubc.cs.ferret.pde.bundlesimportingpackage">
 		 <parameter
-		   class="org.eclipse.pde.internal.core.text.bundle.PackageObject"
+		   class="ca.ubc.cs.ferret.pde.JavaPackage"
 		   count="+"
 		   fidelity="equivalent">
 		 </parameter>

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/JavaPackage.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/JavaPackage.java
@@ -1,5 +1,6 @@
 package ca.ubc.cs.ferret.pde;
 
+/** Representation of a named Java Package. */
 public class JavaPackage {
 	private String pkg;
 

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeModelHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeModelHelper.java
@@ -70,7 +70,6 @@ import org.eclipse.pde.internal.core.plugin.ExternalFragmentModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModel;
 import org.eclipse.pde.internal.core.plugin.ExternalPluginModelBase;
 import org.eclipse.pde.internal.core.plugin.PluginHandler;
-import org.eclipse.pde.internal.core.text.bundle.PackageObject;
 
 public class PdeModelHelper implements IPluginModelListener, IRegistryChangeListener {
 	protected static PdeModelHelper singleton;
@@ -537,14 +536,14 @@ public class PdeModelHelper implements IPluginModelListener, IRegistryChangeList
 		return dependents;
 	}
 
-	public Collection<IPluginModelBase> getBundlesImporting(PackageObject pkg) {
+	public Collection<IPluginModelBase> getBundlesImporting(JavaPackage pkg) {
 		verifyModelCaches();
 		LinkedList<IPluginModelBase> importers = new LinkedList<IPluginModelBase>();
 		for(IPluginModelBase pmb : models.values()) {
 			ImportPackageSpecification[] imports =
 					pmb.getBundleDescription().getImportPackages();
 			for(ImportPackageSpecification dep : imports) {
-				if(pkg.getName().equals(dep.getName())) {
+				if (pkg.getPackage().equals(dep.getName())) {
 					importers.add(pmb);
 				}
 			}
@@ -552,14 +551,14 @@ public class PdeModelHelper implements IPluginModelListener, IRegistryChangeList
 		return importers;
 	}
 
-	public Collection<IPluginModelBase> getBundlesExporting(PackageObject pkg) {
+	public Collection<IPluginModelBase> getBundlesExporting(JavaPackage pkg) {
 		verifyModelCaches();
 		LinkedList<IPluginModelBase> exporters = new LinkedList<IPluginModelBase>();
 		for(IPluginModelBase pmb : models.values()) {
 			ExportPackageDescription[] exports =
 					pmb.getBundleDescription().getExportPackages();
 			for(ExportPackageDescription dep : exports) {
-				if(pkg.getName().equals(dep.getName())) {
+				if (pkg.getPackage().equals(dep.getName())) {
 					exporters.add(pmb);
 				}
 			}

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/queries/BundlesExportingPackage.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/queries/BundlesExportingPackage.java
@@ -1,17 +1,15 @@
 package ca.ubc.cs.ferret.pde.queries;
 
-import java.util.Collection;
-
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.pde.core.plugin.IPluginModelBase;
-import org.eclipse.pde.internal.core.text.bundle.PackageObject;
-
 import ca.ubc.cs.ferret.model.AbstractIntersectionConceptualQuery;
 import ca.ubc.cs.ferret.model.SimpleSolution;
+import ca.ubc.cs.ferret.pde.JavaPackage;
 import ca.ubc.cs.ferret.pde.PdeModelHelper;
+import java.util.Collection;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
 
 public class BundlesExportingPackage extends
-		AbstractIntersectionConceptualQuery<PackageObject, IPluginModelBase> {
+		AbstractIntersectionConceptualQuery<JavaPackage, IPluginModelBase> {
 
 	@Override
 	protected String getSubDescription() {
@@ -19,7 +17,7 @@ public class BundlesExportingPackage extends
 	}
 
 	@Override
-	protected Collection<IPluginModelBase> performQuery(PackageObject pkg,
+	protected Collection<IPluginModelBase> performQuery(JavaPackage pkg,
 			IProgressMonitor monitor) {
 		return PdeModelHelper.getDefault().getBundlesExporting(pkg);
 	}

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/queries/BundlesImportingPackage.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/queries/BundlesImportingPackage.java
@@ -1,17 +1,15 @@
 package ca.ubc.cs.ferret.pde.queries;
 
-import java.util.Collection;
-
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.pde.core.plugin.IPluginModelBase;
-import org.eclipse.pde.internal.core.text.bundle.PackageObject;
-
 import ca.ubc.cs.ferret.model.AbstractIntersectionConceptualQuery;
 import ca.ubc.cs.ferret.model.SimpleSolution;
+import ca.ubc.cs.ferret.pde.JavaPackage;
 import ca.ubc.cs.ferret.pde.PdeModelHelper;
+import java.util.Collection;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.pde.core.plugin.IPluginModelBase;
 
 public class BundlesImportingPackage extends
-		AbstractIntersectionConceptualQuery<PackageObject, IPluginModelBase> {
+		AbstractIntersectionConceptualQuery<JavaPackage, IPluginModelBase> {
 
 	@Override
 	protected String getSubDescription() {
@@ -19,7 +17,7 @@ public class BundlesImportingPackage extends
 	}
 
 	@Override
-	protected Collection<IPluginModelBase> performQuery(PackageObject pkg,
+	protected Collection<IPluginModelBase> performQuery(JavaPackage pkg,
 			IProgressMonitor monitor) {
 		return PdeModelHelper.getDefault().getBundlesImporting(pkg);
 	}


### PR DESCRIPTION
Changes _bundles importing package_ and _bundles exporting package_ to use intermediate package representation.  Otherwise selecting a package fragment from the Java Browsing perspective does not do the right thing.