### PR TITLE
Provide useful sphere configuration out-of-the-box

### DIFF
--- a/ca.ubc.cs.ferret.pde/plugin.xml
+++ b/ca.ubc.cs.ferret.pde/plugin.xml
@@ -253,6 +253,15 @@
            objectType="org.eclipse.jdt.core.IMember" />
   </extension>
 
+   <extension
+         point="ca.ubc.cs.ferret.sphereConfigurations">
+      <factory
+            class="ca.ubc.cs.ferret.pde.ui.JdtPdeSphereFactory"
+            description="JDT+PDE"
+            id="jdt+pde">
+      </factory>
+   </extension>
+
     <extension point="org.eclipse.help.contexts">
         <contexts file="helpContexts.xml"  />
     </extension>

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereFactory.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereFactory.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2017 Manumitting Technologies Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Manumitting Technologies Inc - initial API and implementation
+ *******************************************************************************/
+
+package ca.ubc.cs.ferret.pde;
+
+import ca.ubc.cs.ferret.FerretConfigurationException;
+import ca.ubc.cs.ferret.model.AbstractSphereFactory;
+import ca.ubc.cs.ferret.model.ISphere;
+import ca.ubc.cs.ferret.model.ObjectOrientedRelations;
+import ca.ubc.cs.ferret.model.Sphere;
+import ca.ubc.cs.ferret.pde.relations.AdaptableFromRelation;
+import ca.ubc.cs.ferret.pde.relations.AdaptableToRelation;
+import ca.ubc.cs.ferret.pde.relations.PdeExtensionPointExtensions;
+import ca.ubc.cs.ferret.pde.relations.PdeExtensionsExtensionPoint;
+import ca.ubc.cs.ferret.pde.relations.PdeIdentifierReferencedRelation;
+import ca.ubc.cs.ferret.pde.relations.PdePluginDeclaredExtensionPoints;
+import ca.ubc.cs.ferret.pde.relations.PdePluginDeclaredExtensions;
+import ca.ubc.cs.ferret.pde.relations.PdeTypesReferencedRelation;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+/**
+ *
+ */
+public class PdeSphereFactory extends AbstractSphereFactory {
+	public String getId() {
+		return getClass().getName();
+	}
+
+	public String getDescription() {
+		return "Eclipse plugin-related queries (PDE)";
+	}
+
+	public IStatus canCreate() {
+		return Status.OK_STATUS;
+	}
+
+	public ISphere createSphere(IProgressMonitor monitor)
+			throws FerretConfigurationException {
+		Sphere tb = new Sphere("Eclipse PDE target image information");
+		tb.register(ObjectOrientedRelations.OP_TYPES_REFERENCED,
+				new PdeTypesReferencedRelation());
+		tb.register(PdeSphereHelper.OP_DECLARED_EXTENSION_POINTS,
+				new PdePluginDeclaredExtensionPoints(),
+				new PdeExtensionsExtensionPoint());
+		tb.register(PdeSphereHelper.OP_DECLARED_EXTENSIONS, new PdePluginDeclaredExtensions(),
+				new PdeExtensionPointExtensions());
+		tb.register(PdeSphereHelper.OP_IDENTIFIER_REFERENCED,
+				new PdeIdentifierReferencedRelation());
+		tb.register(PdeSphereHelper.OP_EXTENDED_BY, new PdeExtensionPointExtensions());
+		tb.register(PdeSphereHelper.OP_EXTENDS, new PdeExtensionsExtensionPoint());
+		tb.register(PdeSphereHelper.OP_ADAPTABLE_FROM, new AdaptableFromRelation());
+		tb.register(PdeSphereHelper.OP_ADAPTABLE_TO, new AdaptableToRelation());
+		return tb;
+	}
+
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	public ImageDescriptor getImageDescriptor() {
+		return FerretPdePlugin.getImageDescriptor("icons/pde-tb.gif");
+	}
+
+	public String getHelpContextId() {
+		return PdeSphereHelper.HCI_PDE_TB;
+	}
+}

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
@@ -4,27 +4,11 @@
  */
 package ca.ubc.cs.ferret.pde;
 
-import ca.ubc.cs.ferret.FerretConfigurationException;
-import ca.ubc.cs.ferret.model.AbstractSphereFactory;
-import ca.ubc.cs.ferret.model.ISphere;
 import ca.ubc.cs.ferret.model.ISphereFactory;
-import ca.ubc.cs.ferret.model.ObjectOrientedRelations;
-import ca.ubc.cs.ferret.model.Sphere;
 import ca.ubc.cs.ferret.model.SphereHelper;
-import ca.ubc.cs.ferret.pde.relations.AdaptableFromRelation;
-import ca.ubc.cs.ferret.pde.relations.AdaptableToRelation;
-import ca.ubc.cs.ferret.pde.relations.PdeExtensionPointExtensions;
-import ca.ubc.cs.ferret.pde.relations.PdeExtensionsExtensionPoint;
-import ca.ubc.cs.ferret.pde.relations.PdeIdentifierReferencedRelation;
-import ca.ubc.cs.ferret.pde.relations.PdePluginDeclaredExtensionPoints;
-import ca.ubc.cs.ferret.pde.relations.PdePluginDeclaredExtensions;
-import ca.ubc.cs.ferret.pde.relations.PdeTypesReferencedRelation;
 import ca.ubc.cs.ferret.views.ImageImageDescriptor;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
@@ -176,52 +160,7 @@ public class PdeSphereHelper extends SphereHelper {
 	}
 
 	public ISphereFactory[] getSphereFactories() {
-		return new ISphereFactory[] { new AbstractSphereFactory() {
-
-			public String getId() {
-				return getClass().getName();
-			}
-
-			public String getDescription() {
-				return "Eclipse plugin-related queries (PDE)";
-			}
-
-			public IStatus canCreate() {
-				return Status.OK_STATUS;
-			}
-
-			public ISphere createSphere(IProgressMonitor monitor)
-					throws FerretConfigurationException {
-				Sphere tb = new Sphere("Eclipse PDE target image information");
-				tb.register(ObjectOrientedRelations.OP_TYPES_REFERENCED,
-						new PdeTypesReferencedRelation());
-				tb.register(OP_DECLARED_EXTENSION_POINTS,
-						new PdePluginDeclaredExtensionPoints(),
-						new PdeExtensionsExtensionPoint());
-				tb.register(OP_DECLARED_EXTENSIONS, new PdePluginDeclaredExtensions(),
-						new PdeExtensionPointExtensions());
-				tb.register(OP_IDENTIFIER_REFERENCED,
-						new PdeIdentifierReferencedRelation());
-				tb.register(OP_EXTENDED_BY, new PdeExtensionPointExtensions());
-				tb.register(OP_EXTENDS, new PdeExtensionsExtensionPoint());
-				tb.register(OP_ADAPTABLE_FROM, new AdaptableFromRelation());
-				tb.register(OP_ADAPTABLE_TO, new AdaptableToRelation());
-				return tb;
-			}
-
-			@SuppressWarnings("unchecked")
-			public <T> T getAdapter(Class<T> adapter) {
-				return null;
-			}
-
-			public ImageDescriptor getImageDescriptor() {
-				return FerretPdePlugin.getImageDescriptor("icons/pde-tb.gif");
-			}
-
-			public String getHelpContextId() {
-				return HCI_PDE_TB;
-			}
-		} };
+		return new ISphereFactory[] { new PdeSphereFactory() };
 
 	}
 

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
@@ -1,7 +1,13 @@
-/*
- * Copyright 2005 by X.
- * @author bsd
- */
+/*******************************************************************************
+ * Copyright (c) 2005 Brian de Alwis and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Brian de Alwis - initial API and implementation
+ *******************************************************************************/
 package ca.ubc.cs.ferret.pde;
 
 import ca.ubc.cs.ferret.model.ISphereFactory;

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/ui/JdtPdeSphereFactory.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/ui/JdtPdeSphereFactory.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Manumitting Technologies Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Manumitting Technologies Inc - initial API and implementation
+ *******************************************************************************/
+
+package ca.ubc.cs.ferret.pde.ui;
+
+import ca.ubc.cs.ferret.jdt.JdtSphereFactory;
+import ca.ubc.cs.ferret.pde.PdeSphereFactory;
+import ca.ubc.cs.ferret.sphereconfig.ReplacementSphereCompositorFactory;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IExecutableExtensionFactory;
+
+public class JdtPdeSphereFactory implements IExecutableExtensionFactory {
+	@Override
+	public Object create() throws CoreException {
+		ReplacementSphereCompositorFactory root = new ReplacementSphereCompositorFactory();
+		root.add(new JdtSphereFactory());
+		root.add(new PdeSphereFactory());
+		return root;
+	}
+}

--- a/ca.ubc.cs.ferret/plugin.xml
+++ b/ca.ubc.cs.ferret/plugin.xml
@@ -7,6 +7,7 @@
    <extension-point id="query_stimulants" name="Stimulants prompting queries" schema="schema/query_stimulants.exsd"/>
    <extension-point id="typeConverters" name="Ferret Type Converters" schema="schema/typeConverters.exsd"/>
    <extension-point id="scfs" name="Sphere Composition Functions" schema="schema/scfs.exsd"/>
+   <extension-point id="sphereConfigurations" name="Preconfigure Sphere Configurations" schema="schema/sphereConfigurations.exsd"/>
 
    <extension point="org.eclipse.ui.views">
       <category

--- a/ca.ubc.cs.ferret/schema/sphereConfigurations.exsd
+++ b/ca.ubc.cs.ferret/schema/sphereConfigurations.exsd
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="ca.ubc.cs.ferret" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="ca.ubc.cs.ferret" id="sphereConfigurations" name="Preconfigure Sphere Configurations"/>
+      </appInfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="factory"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="factory">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":ca.ubc.cs.ferret.model.ISphereFactory"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="description" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A succinct description to show in a menu item to describe this sphere configuration.
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="helpContextId" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="icon" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="resource"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/ICallback.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/ICallback.java
@@ -10,6 +10,7 @@ package ca.ubc.cs.ferret;
  * @author bsd
  * @see java.lang.Runnable
  */
+@FunctionalInterface
 public interface ICallback<T> {
     /**
      * Run this runnable with the given argument.  The content of the argument

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/model/AbstractSphereFactory.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/model/AbstractSphereFactory.java
@@ -1,6 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2017 Manumitting Technologies Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Manumitting Technologies Inc - initial API and implementation
+ *******************************************************************************/
+
 package ca.ubc.cs.ferret.model;
 
 import ca.ubc.cs.ferret.FerretFatalError;
+import java.util.Objects;
 
 public abstract class AbstractSphereFactory implements ISphereFactory {
 
@@ -13,4 +25,20 @@ public abstract class AbstractSphereFactory implements ISphereFactory {
 		}
 	}
 
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter.isInstance(this)) {
+			return adapter.cast(this);
+		}
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(getId());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return getClass() == obj.getClass() && Objects.equals(getId(), getClass().cast(obj).getId());
+	}
 }

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/model/ExtensionSphereFactory.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/model/ExtensionSphereFactory.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Manumitting Technologies Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Manumitting Technologies Inc - initial API and implementation
+ *******************************************************************************/
+
+package ca.ubc.cs.ferret.model;
+
+import ca.ubc.cs.ferret.FerretConfigurationException;
+import ca.ubc.cs.ferret.FerretPlugin;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.internal.menus.MenuHelper;
+
+/**
+ * A sphere factory driven from the
+ * {@code ca.ubc.cs.ferret.sphereConfigurations} extension point.
+ */
+public class ExtensionSphereFactory extends AbstractSphereFactory {
+	private IConfigurationElement configElement;
+	private ISphereFactory wrapped;
+
+	public ExtensionSphereFactory(IConfigurationElement ce) {
+		this.configElement = ce;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == ISphereFactory.class) {
+			try {
+				return adapter.cast(getWrapped());
+			} catch (CoreException ex) {
+				FerretPlugin.log(ex);
+				return null;
+			}
+		}
+		return super.getAdapter(adapter);
+	}
+
+	@Override
+	public String getId() {
+		return configElement.getAttribute("id");
+	}
+
+	@Override
+	public String getDescription() {
+		return configElement.getAttribute("description");
+	}
+
+	@Override
+	public IStatus canCreate() {
+		try {
+			return getWrapped().canCreate();
+		} catch (CoreException ex) {
+			FerretPlugin.log(ex);
+			return ex.getStatus();
+		}
+	}
+
+	private ISphereFactory getWrapped() throws CoreException {
+		if (wrapped != null) {
+			return wrapped;
+		}
+		return wrapped = (ISphereFactory) configElement.createExecutableExtension("class");
+	}
+
+	@Override
+	public ISphere createSphere(IProgressMonitor monitor) throws FerretConfigurationException {
+		try {
+			return getWrapped().createSphere(monitor);
+		} catch (CoreException ex) {
+			throw new FerretConfigurationException(ex.getStatus());
+		}
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+		String uri = MenuHelper.getIconURI(configElement, "icon");
+		if (uri == null) {
+			return null;
+		}
+		try {
+			return ImageDescriptor.createFromURL(new URL(uri));
+		} catch (MalformedURLException ex) {
+			return null;
+		}
+	}
+
+	@Override
+	public String getHelpContextId() {
+		return configElement.getAttribute("helpContextId");
+	}
+}

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/sphereconfig/AbstractSphereCompositorFactory.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/sphereconfig/AbstractSphereCompositorFactory.java
@@ -1,8 +1,15 @@
 package ca.ubc.cs.ferret.sphereconfig;
 
+import ca.ubc.cs.ferret.FerretConfigurationException;
+import ca.ubc.cs.ferret.FerretErrorConstants;
+import ca.ubc.cs.ferret.FerretPlugin;
+import ca.ubc.cs.ferret.model.AbstractSphereFactory;
+import ca.ubc.cs.ferret.model.ISphere;
+import ca.ubc.cs.ferret.model.ISphereCompositor;
+import ca.ubc.cs.ferret.model.ISphereCompositorFactory;
+import ca.ubc.cs.ferret.model.ISphereFactory;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExecutableExtension;
@@ -12,16 +19,6 @@ import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-
-import ca.ubc.cs.ferret.FerretConfigurationException;
-import ca.ubc.cs.ferret.FerretErrorConstants;
-import ca.ubc.cs.ferret.FerretFatalError;
-import ca.ubc.cs.ferret.FerretPlugin;
-import ca.ubc.cs.ferret.model.AbstractSphereFactory;
-import ca.ubc.cs.ferret.model.ISphere;
-import ca.ubc.cs.ferret.model.ISphereCompositor;
-import ca.ubc.cs.ferret.model.ISphereCompositorFactory;
-import ca.ubc.cs.ferret.model.ISphereFactory;
 
 public abstract class AbstractSphereCompositorFactory 
 		extends AbstractSphereFactory
@@ -77,10 +74,6 @@ public abstract class AbstractSphereCompositorFactory
 	}
 	
 	public abstract IStatus canCreateCompositor();
-
-	public <T> T getAdapter(Class<T> adapter) {
-		return null;
-	}
 
 	public String getId() {
 		return getClass().getName();

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>ca.ubc.cs.ferret.pde</module>
     <module>ca.ubc.cs.ferret.tests</module>
     <module>ca.ubc.cs.ferret.jung</module>
+    <module>ca.ubc.cs.ferret.config.jdtpde</module>
 <!--
   Kenyon is no longer with us
     <module>ca.ubc.cs.ferret.kenyon</module>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <module>ca.ubc.cs.ferret.pde</module>
     <module>ca.ubc.cs.ferret.tests</module>
     <module>ca.ubc.cs.ferret.jung</module>
-    <module>ca.ubc.cs.ferret.config.jdtpde</module>
 <!--
   Kenyon is no longer with us
     <module>ca.ubc.cs.ferret.kenyon</module>


### PR DESCRIPTION
  - add extension point for contributing sphere configurations (essentially exposing an `ISphereFactory`)
  - save an restore the last used contributed sphere configuration (if any)
  - automatically select one of the contributed sphere configurations on start (first one wins)
  - contribute default JDT+PDE sphere definition

Fixes #7 