### PR TITLE
Don't reissue queries on breakpoint change

### DIFF
--- a/ca.ubc.cs.ferret.jdt/src/ca/ubc/cs/ferret/jdt/JavaModelHelper.java
+++ b/ca.ubc.cs.ferret.jdt/src/ca/ubc/cs/ferret/jdt/JavaModelHelper.java
@@ -325,27 +325,30 @@ public class JavaModelHelper implements IElementChangedListener {
     }
 
     /* On JDT change, we wipe out our caches */
-    public void elementChanged(ElementChangedEvent event) {
-    	// System.out.println("JDT elementChanged: " + event);
-    	if(contentChanged(event.getDelta())) {
-    		if(FerretPlugin.hasDebugOption("debug/cacheMaintenance")) {
-    			System.out.println("JDT Element Changed: Resetting JDT cache");
-    		}
-    		reset();
-    		javaModelCounter++;
-    	}
-    }
+	public void elementChanged(ElementChangedEvent event) {
+		if (contentChanged(event.getDelta())) {
+			if (FerretPlugin.hasDebugOption("debug/cacheMaintenance")) {
+				System.out.println("JDT Element Changed: Resetting JDT cache");
+			}
+			reset();
+			javaModelCounter++;
+		}
+	}
 
-    protected boolean contentChanged(IJavaElementDelta delta) {   
-    	if((delta.getFlags() & (IJavaElementDelta.F_REORDER | IJavaElementDelta.F_SOURCEATTACHED 
-    			| IJavaElementDelta.F_SOURCEDETACHED)) == 0) {
-    		return true;
-    	}
-    	for(IJavaElementDelta child : delta.getAffectedChildren()) {
-    		if(contentChanged(child)) { return true; }
-    	}
-    	return false;
-    }
+	protected boolean contentChanged(IJavaElementDelta delta) {
+		int ignoredChangeTypes = IJavaElementDelta.F_PRIMARY_WORKING_COPY | IJavaElementDelta.F_AST_AFFECTED
+				| IJavaElementDelta.F_CATEGORIES | IJavaElementDelta.F_SOURCEATTACHED
+				| IJavaElementDelta.F_SOURCEDETACHED | IJavaElementDelta.F_CHILDREN;
+		if ((delta.getFlags() & ~ignoredChangeTypes) != 0) {
+			return true;
+		}
+		for (IJavaElementDelta child : delta.getAffectedChildren()) {
+			if (contentChanged(child)) {
+				return true;
+			}
+		}
+		return false;
+	}
     
     protected ASTParser parser = ASTParser.newParser(AST.JLS3);
     

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/ModificationVisitor.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/ModificationVisitor.java
@@ -18,23 +18,19 @@ import org.eclipse.core.runtime.CoreException;
  * Walk a resource delta to see if there was an actual change in content or
  * movement.  Ignore changes to markers (MARKER), description (DESCRIPTION),
  * and synchronization information (SYNC).
- * @author bsd
  */
 public class ModificationVisitor implements IResourceDeltaVisitor {
     protected boolean wasModified = false;
     
-    public ModificationVisitor() {
-    }
-
-    protected static int ignoredFlags = IResourceDelta.MARKERS
-            & IResourceDelta.DESCRIPTION & IResourceDelta.SYNC;
+	protected static final int ignoredFlags = IResourceDelta.MARKERS
+			| IResourceDelta.DESCRIPTION | IResourceDelta.SYNC;
 
     public boolean visit(IResourceDelta delta) throws CoreException {
         int eventFlags = delta.getFlags();
         if((eventFlags & ~ignoredFlags) != 0) {
             wasModified = true;
         }
-//      if we've determined is was a modification, then don't bother continuing
+		// if we've determined is was a modification, then don't bother continuing
         return !wasModified;    
     }
 


### PR DESCRIPTION
Bitfields must use `|`, not `&`.
/me sigh
Limit `JavaModelHelper` resets to real java model changes.

Fixes #46 