### PR TITLE
Handle signature change in PDE FeatureEditor.openFeatureEditor()

### DIFF
--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
@@ -13,7 +13,9 @@ package ca.ubc.cs.ferret.pde;
 import ca.ubc.cs.ferret.FerretPlugin;
 import ca.ubc.cs.ferret.model.ISphereFactory;
 import ca.ubc.cs.ferret.model.SphereHelper;
+import ca.ubc.cs.ferret.util.ReflectionUtils;
 import ca.ubc.cs.ferret.views.ImageImageDescriptor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -161,7 +163,15 @@ public class PdeSphereHelper extends SphereHelper {
 			return true;
 		}
 		if (element instanceof IFeatureModel) {
-			FeatureEditor.openFeatureEditor((IFeatureModel) element);
+			// Bug 438509 (Oxygen) changed the return type of openFeatureEditor
+			// from void to IEditorPart
+			try {
+				ReflectionUtils.invokeVoid(FeatureEditor.class, "openFeatureEditor",
+						new Class[] { IFeatureModel.class }, element);
+			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException ex) {
+				FerretPlugin.log(ex);
+			}
 			return true;
 		}
 		return super.openObject(element);

--- a/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/util/ReflectionUtils.java
+++ b/ca.ubc.cs.ferret/src/ca/ubc/cs/ferret/util/ReflectionUtils.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Brian de Alwis, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Brian de Alwis - initial API and implementation
+ *******************************************************************************/
+
+
+package ca.ubc.cs.ferret.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Utility methods for reflective access and invokation.
+ */
+public class ReflectionUtils {
+	/** Invoke a method without regard to its return type. */
+	public static void invokeVoid(Object object, String methodName, Class<?>[] parameterTypes, Object... parameters)
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
+			InvocationTargetException {
+		Class<?> clazz = object instanceof Class<?> ? (Class<?>) object : object.getClass();
+		Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
+		method.setAccessible(true);
+		method.invoke(object, parameters);
+	}
+
+	// not intended to be created
+	private ReflectionUtils() {
+	}
+}


### PR DESCRIPTION
[Eclipse bug 438509](https://bugs.eclipse.org/438509) caused the method signature for `FeatureEditor.openFeatureEditor(IFeatureModel)` to change from being `void` to returning an `IEditorPart`, which breaks Ferret on Oxygen and above.  Since `FeatureEditor` is an internal class, that's just something we have to handle.  So invoke the method via reflection instead.