### PR TITLE
 Support resolving text strings contained in files in external jars

### DIFF
--- a/ca.ubc.cs.ferret.jdt/src/ca/ubc/cs/ferret/jdt/JdtSphereHelper.java
+++ b/ca.ubc.cs.ferret.jdt/src/ca/ubc/cs/ferret/jdt/JdtSphereHelper.java
@@ -171,6 +171,9 @@ public class JdtSphereHelper extends SphereHelper {
 		}
 
 		IEditorInput input = editor.getEditorInput();
+		if ((container = TypesConversionManager.getAdapter(input, IJavaElement.class, Fidelity.Exact)) != null) {
+			return container;
+		}
 		if (input instanceof FileEditorInput) {
 			IFile file = ((FileEditorInput) input).getFile();
 			container = JavaCore.create(file);
@@ -183,19 +186,20 @@ public class JdtSphereHelper extends SphereHelper {
 			}
 		}
 
-		IFile file = input.getAdapter(IFile.class);
-		container = JavaCore.create((IFile) input);
-		if (container != null) {
-			return container;
-		}
-		container = JavaCore.create(file.getProject());
-		if (container != null) {
-			return container;
+		IFile file = TypesConversionManager.getAdapter(input, IFile.class, Fidelity.Exact);
+		if (file != null) {
+			container = JavaCore.create(file);
+			if (container != null) {
+				return container;
+			}
+			container = JavaCore.create(file.getProject());
+			if (container != null) {
+				return container;
+			}
 		}
 
-		IProject project = input.getAdapter(IProject.class);
-		container = JavaCore.create(project);
-		if (container != null) {
+		IProject project = TypesConversionManager.getAdapter(input, IProject.class, Fidelity.Exact);
+		if (project != null && (container = JavaCore.create(project)) != null) {
 			return container;
 		}
 		return null;

--- a/ca.ubc.cs.ferret.pde/plugin.xml
+++ b/ca.ubc.cs.ferret.pde/plugin.xml
@@ -265,5 +265,18 @@
     <extension point="org.eclipse.help.contexts">
         <contexts file="helpContexts.xml"  />
     </extension>
+    <extension
+          point="org.eclipse.core.runtime.adapters">
+       <factory
+             adaptableType="org.eclipse.ui.IStorageEditorInput"
+             class="ca.ubc.cs.ferret.pde.JarFileAdapterFactory">
+          <adapter
+                type="org.eclipse.jdt.core.IJavaElement">
+          </adapter>
+          <adapter
+                type="org.eclipse.jdt.core.IPackageFragmentRoot">
+          </adapter>
+       </factory>
+    </extension>
 
 </plugin>

--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/JarFileAdapterFactory.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/JarFileAdapterFactory.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2005 Brian de Alwis, UBC, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Brian de Alwis - initial API and implementation
+ *******************************************************************************/
+package ca.ubc.cs.ferret.pde;
+
+import java.io.File;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.pde.internal.core.PDECore;
+import org.eclipse.ui.IStorageEditorInput;
+
+/**
+ * Adapts jar files to an IPackageFragmentRoot via the PDE search management.
+ */
+public class JarFileAdapterFactory implements IAdapterFactory {
+
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		if (adaptableObject instanceof IStorageEditorInput) {
+			IStorageEditorInput input = (IStorageEditorInput) adaptableObject;
+			File file = input.getAdapter(File.class);
+			if (file != null) {
+				Object adapted = PDECore.getDefault().getSearchablePluginsManager().createAdapterChild(null, file);
+				if (adapterType.isInstance(adapted)) {
+					return adapterType.cast(adapted);
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+		return new Class<?>[] { IJavaElement.class, IPackageFragmentRoot.class };
+	}
+
+}


### PR DESCRIPTION
The `JdtSphereHelper#getSelectedObjects()` is currently unable to resolve package or type names from files hosted in external jars (e.g., from a target platform) as these files are opened from an `IStorage` rather than a from an `IProject`, and thus a JDT `IJavaProject` cannot be found.

PDE has the same problem and creates a proxy project which references these external jars, called _External Plug-ins_.  This project then exposes the jar contents to JDT.  This patch adds an adapter to turn `IStorageEditorInput`s to a JDT `IPackageFragmentRoot` via PDE.

