### PR TITLE
Speed prettyPrint() by avoiding toString on non-PDE objects

### DIFF
--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
@@ -92,8 +92,9 @@ public class PdeSphereHelper extends SphereHelper {
 					+ PdeModelHelper.getDefault().getPluginId(extension.getPluginModel()); //$NON-NLS-1$
 		} else if(element instanceof ISharedPluginModel) { return PdeModelHelper
 				.getDefault().getPluginId((ISharedPluginModel)element); }
-		return getMeaningfulLabel(element, PDEPlugin.getDefault().getLabelProvider()
-				.getText(element));
+		// return getMeaningfulLabel(element, PDEPlugin.getDefault().getLabelProvider()
+		// .getText(element));
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
In `prettyPrint()` avoid doing anything to non-PDE types: this was calling `toString()` on a JDT `TypeHierarchy`, which was unnecessary and expensive
