### PR TITLE
Fix error in IStatus.getCode() -> getSeverity()

### DIFF
--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/relations/PdeTypesReferencedRelation.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/relations/PdeTypesReferencedRelation.java
@@ -58,7 +58,7 @@ public class PdeTypesReferencedRelation extends
     	if(po instanceof IPluginAttribute) {
     		IPluginAttribute attr = (IPluginAttribute)po; 
     		IStatus status = JavaConventions.validateJavaTypeName(attr.getValue().trim());
-    		if(status.getCode() != IStatus.ERROR) {
+			if (status.getSeverity() != IStatus.ERROR) {
     			IType t = JavaModelHelper.getDefault().resolveType(attr.getValue());
     			if(t != null) { types.add(t); }
     		}


### PR DESCRIPTION
When pulling out all type references from a plugin.xml extension stanza, we first that an attribute value is a valid type name with `JavaConventions` to save some effort.  But we were checking the error-code (`IStatus#getCode()`) rather than the severity (`IStatus#getSeverity()`).