### PR TITLE
Must pretty print PDE IModel instances

### DIFF
--- a/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
+++ b/ca.ubc.cs.ferret.pde/src/ca/ubc/cs/ferret/pde/PdeSphereHelper.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.pde.core.IModel;
 import org.eclipse.pde.core.plugin.IPluginExtension;
 import org.eclipse.pde.core.plugin.IPluginExtensionPoint;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
@@ -83,17 +84,17 @@ public class PdeSphereHelper extends SphereHelper {
 
 	@Override
 	public String getLabel(Object element) {
-		if(element instanceof IPluginExtensionPoint) {
-			return PdeModelHelper.getDefault().getFullId((IPluginExtensionPoint)element);
-		} else if(element instanceof IPluginExtension) {
+		if (element instanceof IPluginExtensionPoint) {
+			return PdeModelHelper.getDefault().getFullId((IPluginExtensionPoint) element);
+		} else if (element instanceof IPluginExtension) {
 			// stolen from PluginSearchResultPage
-			IPluginExtension extension = (IPluginExtension)element;
-			return extension.getPoint() + " - "
-					+ PdeModelHelper.getDefault().getPluginId(extension.getPluginModel()); //$NON-NLS-1$
-		} else if(element instanceof ISharedPluginModel) { return PdeModelHelper
-				.getDefault().getPluginId((ISharedPluginModel)element); }
-		// return getMeaningfulLabel(element, PDEPlugin.getDefault().getLabelProvider()
-		// .getText(element));
+			IPluginExtension extension = (IPluginExtension) element;
+			return extension.getPoint() + " - " + PdeModelHelper.getDefault().getPluginId(extension.getPluginModel()); // $NON-NLS-1$
+		} else if (element instanceof ISharedPluginModel) {
+			return PdeModelHelper.getDefault().getPluginId((ISharedPluginModel) element);
+		} else if (element instanceof IModel) {
+			return getMeaningfulLabel(element, PDEPlugin.getDefault().getLabelProvider().getText(element));
+		}
 		return null;
 	}
 


### PR DESCRIPTION
The fix from #72 stopped pretty-printing objects, and as a result:

<img width="404" alt="screen shot 2017-10-24 at 10 34 56 pm" src="https://user-images.githubusercontent.com/202851/31966638-99e5b1da-b90b-11e7-8674-2aaa156affdd.PNG">

We must pretty-print PDE objects.